### PR TITLE
Update plugin to grails 3.3.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-grailsVersion=3.2.3
+grailsVersion=3.3.0
 gradleWrapperVersion=3.0

--- a/grails-app/controllers/umlclassdiagram/UmlController.groovy
+++ b/grails-app/controllers/umlclassdiagram/UmlController.groovy
@@ -3,6 +3,7 @@ package umlclassdiagram
 import grails.validation.Validateable
 import groovy.util.logging.Slf4j
 
+@Slf4j
 class UmlController {
 
     grails.core.GrailsApplication grailsApplication
@@ -10,7 +11,6 @@ class UmlController {
     def umlService
 
     def index() {
-	
         def instance = new ConfigurationCommand()
         bindData(instance, params)
         render(view: 'index', model: [configurationCommandInstance: instance, pluginVersion: pluginVersion])
@@ -63,11 +63,11 @@ class UmlController {
     /**
      * Mitigation for issue #7, and GRAILS-5582
      * @see https://github.com/igorrosenberg/grails-plugin-uml-class-diagram/issues/7
-     * @see https://jira.grails.org/browse/GRAILS-5582, fixed in grails 2.3 
+     * @see https://jira.grails.org/browse/GRAILS-5582, fixed in grails 2.3
      */
-    private void extraBindData(configurationCommandInstance, params) {		
+    private void extraBindData(configurationCommandInstance, params) {
         def oldVersion = grailsApplication.metadata['app.grails.version']
-		if (!oldVersion)	
+		if (!oldVersion)
 			return
 		def version = oldVersion.split('\\.')
         if (version[0].toInteger() < 2 || (version[0].toInteger() == 2 && version[1].toInteger() < 3))

--- a/grails-app/services/umlclassdiagram/PlantUmlService.groovy
+++ b/grails-app/services/umlclassdiagram/PlantUmlService.groovy
@@ -3,10 +3,13 @@ package umlclassdiagram
 import net.sourceforge.plantuml.*
 import com.nafiux.grails.classdomainuml.*
 import org.grails.core.DefaultGrailsDomainClass
+import groovy.util.logging.Slf4j
 
 /**
  * Generate diagrams from a Model.
  */
+
+@Slf4j
 class PlantUmlService {
 
     /*

--- a/grails-app/services/umlclassdiagram/UmlService.groovy
+++ b/grails-app/services/umlclassdiagram/UmlService.groovy
@@ -1,8 +1,12 @@
 package umlclassdiagram
 
+import groovy.util.logging.Slf4j
+
 /**
  * Generate UML diagrams (as images) from application structure.
  */
+
+@Slf4j
 class UmlService {
 
     def modelGeneratorService
@@ -29,5 +33,4 @@ class UmlService {
         def model = modelGeneratorService.makeModel(configurationCommand.diagramType)
         plantUmlService.modelToScript(model, configurationCommand)
     }
-
-}    
+}

--- a/grails-app/services/umlclassdiagram/generator/DomainModelGeneratorService.groovy
+++ b/grails-app/services/umlclassdiagram/generator/DomainModelGeneratorService.groovy
@@ -4,10 +4,13 @@ import static umlclassdiagram.Constants.*
 
 import com.nafiux.grails.classdomainuml.*
 import org.grails.core.DefaultGrailsDomainClass
+import groovy.util.logging.Slf4j
 
 /**
  * Generate UML diagrams from grails domains.
  */
+
+@Slf4j
 class DomainModelGeneratorService extends GrailsArtefactGeneratorService {
 
     def grailsApplication
@@ -30,7 +33,8 @@ class DomainModelGeneratorService extends GrailsArtefactGeneratorService {
         def c = grailsApplication.classLoader.loadClass("${model.fullName}")
         log.debug "Introspect artefact data for ${model.fullName}"
         // FIXME really need an object ? already got a class...
-        def instance = new DefaultGrailsDomainClass(c)
+        def instance = new DefaultGrailsDomainClass(c, grailsApplication.mappingContext)
+        instance.setGrailsApplication(grailsApplication)
         [
                 packageName : model.packageName,
                 className   : model.name,
@@ -47,7 +51,7 @@ class DomainModelGeneratorService extends GrailsArtefactGeneratorService {
         properties.collect {
             def name = it.getName()
             def type = it.getType().name
-            def ref = it.getReferencedPropertyType().name
+            def ref = it.getReferencedPropertyType()?.name
             if (ref == type) {
                 ref = null
             }

--- a/grails-app/services/umlclassdiagram/generator/LayersModelGeneratorService.groovy
+++ b/grails-app/services/umlclassdiagram/generator/LayersModelGeneratorService.groovy
@@ -1,7 +1,9 @@
 package umlclassdiagram.generator
 
 import static umlclassdiagram.Constants.*
+import groovy.util.logging.Slf4j
 
+@Slf4j
 class LayersModelGeneratorService extends GrailsArtefactGeneratorService {
 
     def grailsApplication

--- a/src/main/groovy/groovy/grails/plugin/umlclassdiagram/UmlClassDiagramGrailsPlugin.groovy
+++ b/src/main/groovy/groovy/grails/plugin/umlclassdiagram/UmlClassDiagramGrailsPlugin.groovy
@@ -5,14 +5,14 @@ import grails.plugins.*
 class UmlClassDiagramGrailsPlugin extends Plugin {
 
     // the version or versions of Grails the plugin is designed for
-    def grailsVersion = "3.2.3 > *"
+    def grailsVersion = "3.3.0 > *"
     // resources that are excluded from plugin packaging
     def pluginExcludes = [
         "grails-app/views/error.gsp"
     ]
 
     def profiles = ['web']
-	
+
     def title = "Uml Class Diagram" // Headline display name of the plugin
     def author = "Igor Rosenberg"
     def description = 'Generate UML class diagrams from your Grails app source code.'


### PR DESCRIPTION
The grailsApplication and mappingContext properties of DefaultGrailsDomainClass have to be set explicitly instead of relying on spring to initialise them automatically.

I don't know the exact reason but the Service and Controller classes no longer automatically have a `log` property. An explicit @Slf4j seems to fix the issue.
